### PR TITLE
python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ package_dir =
     = src
 packages =
     its_preselector
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     requests>=2.25.1
 


### PR DESCRIPTION
Change to require at least python 3.7 because it wouldn't build in 3.6. 