### PR TITLE
Remove python 3.7 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Missed this in #13, which rolled up the minimum Python version from 3.7 to 3.8.

This PR simply removes the incorrect (after #13) metadata classifier indicating Python 3.7 compatibility from the `pyproject.toml` file.